### PR TITLE
Add inline bold support

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ function indent(slide, indent) {
     space += ' '
 
   var code = false
+  var inlineBold = /\*\*(.*)\*\*/g
   return slide.split('\n').map(function (l) {
     if(/^#/.test(l))
       l = l.bold


### PR DESCRIPTION
This PR adds support for inline bold styling in tslide.
### Before

![bold-before](https://cloud.githubusercontent.com/assets/87162/13765105/dd44a398-ea34-11e5-8fec-7dd8ee300d74.png)
### After

![bold-after](https://cloud.githubusercontent.com/assets/87162/13765108/e3faf232-ea34-11e5-9834-a78755d7e9bf.png)

---

Let me know if PR looks good. I can make any adjustments if needed.
