### PR TITLE
Add support for remote presentating.

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,11 @@ var js = require('hipster/highlight/javascript')
 var imgcat = require('ansi-escapes').image
 
 var file = opts._[0]
+if (!file) {
+  console.error('USAGE: tslide [markdown-file]')
+  process.exit(1)
+}
+
 var text = require('fs').readFileSync(file, 'utf-8')
 var slides = text.split(/---+\n/)
 if(slides.length <= 1) {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 #! /usr/bin/env node
-
 require('colors')
 
-var charm = require('charm')(process.stdout)
+var charmer = require('charm')
 var keypress = require('keypress')(process.stdin)
 var opts = require('optimist').default('images', true).argv
 var fs = require('fs')
@@ -10,12 +9,38 @@ var path = require('path')
 var iq = require('insert-queue')
 var js = require('hipster/highlight/javascript')
 var imgcat = require('ansi-escapes').image
+var http = require('http')
 
-var file = opts._[0]
-if (!file) {
-  console.error('USAGE: tslide [markdown-file]')
+var speaker = opts.speaker || opts.s
+var present = opts.present || opts.p
+if (speaker && present) {
+  console.error('Cannot run tslide as both speaker and presenter.')
   process.exit(1)
 }
+
+var file = opts._[0]
+if (!file && !present) {
+  console.error('USAGE: tslide [markdown-file] [-s|--speaker] [-p|--present]')
+  console.error()
+  console.error('Pass --speaker to interpret blockquotes as speaker notes. This')
+  console.error('will show the full presentation slides in the current terminal.')
+  console.error()
+  console.error('Run tslide in another terminal with --present. This terminal will')
+  console.error('see the same presentation, but without the speaker notes.')
+  process.exit(1)
+}
+
+var port = 8009
+
+// Connect to the speaker server and stream the response.
+if (present) {
+  http.request({ port: port }, function (res) {
+    res.pipe(process.stdout)
+  }).end()
+  return
+}
+
+var charm = charmer(process.stdout)
 
 var text = require('fs').readFileSync(file, 'utf-8')
 var slides = text.split(/---+\n/)
@@ -23,6 +48,8 @@ if(slides.length <= 1) {
   console.error('markdown should be split into slides by --- (hdiv)')
   process.exit(1)
 }
+var notes = []
+var presenters = []  // presenter http connections
 
 var highlight = opts.highlight !== false
 
@@ -54,6 +81,40 @@ function images (content) {
   return content;
 }
 
+// Removes all blockquotes from 'slides' and populates 'notes' with them.
+function extractNotes () {
+  slides = slides.map(function (slide) {
+    var res = slide.match(/\s+>.*/)
+    if (!res || !res.index) {
+      notes.push('')
+      return slide
+    }
+    var idx = res.index
+    notes.push(slide.substring(idx))
+    return slide.substring(0, idx)
+  })
+}
+
+// Runs an HTTP server that will serve streaming presentation notes in the
+// response.
+function serveNotes () {
+  http.createServer(function (req, res) {
+    var charm = charmer(res)
+    presenters.push(charm)
+  }).listen(port)
+}
+
+// Writes a string to all live HTTP connections.
+function writeSlide (slide) {
+  presenters.forEach(function (pres) {
+    pres
+      .reset()
+      .position(1, mtop)
+      .write(indent(slide, mleft))
+      .position(mleft, process.stdout.rows - 1)
+  })
+}
+
 function show () {
   if(index < 0) index = 0
   if(index >= slides.length) index = slides.length - 1
@@ -68,9 +129,20 @@ function show () {
   charm
     .reset()
     .position(1, mtop)
-    .write(indent(content, mleft))
+    .write(content, mleft))
+    .write(indent(notes[index], mleft))
     .position(mleft, process.stdout.rows - 1)
+
+  writeSlide(slides[index])
 }
+
+// Extract notes and run presentation server, if we're the speaker.
+if (speaker) {
+  extractNotes()
+  serveNotes(port)
+}
+
+// Start presentation
 var index = 0
 show(index)
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "ansi-escapes": "^1.3.0",
-    "charm": "~0.1.0",
+    "charm": "~1.0.1",
     "color": "~0.4.1",
     "colors": "~0.6.0-1",
     "hipster": "~0.9.0",


### PR DESCRIPTION
This adds the optional switches '-p|--present' and '-s|--speaker'.

--speaker will act the same as tslide normally does, except it will also host a local HTTP server that another terminal can connect to using --present. All connections will see the same slides, except with blockquotes stripped -- this lets the speaker see notes on their terminal but not expose them to the viewers.

---

I was considering forking to add this, since it does expand the scope of the module a bit. All functionality is opt-in though, and no server is started unless `--speaker` is provided. I figured I'd pass it by you in case it's something you'd also wouldn't mind seeing in `tslide`! Let me know if there's any UX you think could be made better.

---

This is blocked on https://github.com/substack/node-charm/pull/28 getting merged, since I'm piping different charm instances locally vs to each viewer.

---

![example](http://www.stephenwhitmore.com/tmp/tslide.png)
