### PR TITLE
Fix working dir for images

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var js = require('hipster/highlight/javascript')
 var imgcat = require('ansi-escapes').image
 
 var file = opts._[0]
+var fildWd = path.dirname(file)
 if (!file) {
   console.error('USAGE: tslide [markdown-file]')
   process.exit(1)
@@ -41,7 +42,7 @@ function images (content) {
 
   while (match = pattern.exec(content)) {
     try {
-      var url = path.join(__dirname, match[1])
+      var url = path.join(fildWd, match[1])
 
       image = imgcat(fs.readFileSync(url))
       content = content.replace(match[0], image)


### PR DESCRIPTION
This will make sure that images in markdown are found from the same directory as the supplied markdown file.

I had expected this to be the default behaviour. If you intended the `node_modules/tslide` to be the working directory for images, let me know, and we'll trash this PR!
