### PR TITLE
Add clicker support. Tested with Logitech R800

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ Terminal SlideDeck (for backend devs)
 ---
 
 Controls:
-  * Left, Right, or HJKL: change slide.
-  * Ctrl-C     : exit
+  * Left, Right, or HJKL, Page Up, Page Down: change slide.
+  * Ctrl-C or Esc    : exit
+
+You can alternatively use a presenter. `tslide` works with the Logitech R800 and R400 out of the box.
 
 ---
 
@@ -100,6 +102,7 @@ and received a number of contributions that has made tslide actually pretty good
 * [@rafaelrinaldi](https://github.com/rafaelrinaldi)
 * [@noffle](https://github.com/noffle)
 * [@loklaan](https://github.com/loklaan)
+* [@dkundel](https://github.com/dkundel)
 
 for all the pull requests!
 

--- a/index.js
+++ b/index.js
@@ -93,15 +93,15 @@ process.stdin.resume()
 process.stdin.on('keypress', function (ch, key) {
 
   if(!key) return
-  if(key.ctrl && /c|q/.test(key.name))
+  if((key.ctrl && /c|q/.test(key.name)) || key.name === 'escape')
     charm.reset(), process.exit(0)
-  else if(key.name == 'left' || key.name == 'h' || key.name == 'j')
+  else if(key.name === 'left' || key.name === 'h' || key.name === 'j' || key.name === 'pageup')
     show(--index)
-  else if(key.name == 'right' || key.name == 'k' || key.name == 'l')
+  else if(key.name === 'right' || key.name === 'k' || key.name === 'l' || key.name === 'pagedown')
     show(index ++)
-  else if(key.name == 'home')
+  else if(key.name === 'home')
     show(index = 0)
-  else if(key.name == 'end')
+  else if(key.name === 'end')
     show(index = slides.length - 1)
 })
 


### PR DESCRIPTION
Added clicker support for @yoshuawuyts talk at the Node.js Berlin meetup. I also added quitting the presentation by pressing <kbd>Esc</kbd> which is equivalent to pressing the Start/End presentation button on the clicker.

Mappings added:
<kbd>Esc</kbd> -> Quit presentation
<kbd>Page Up</kbd> -> Previous slide
<kbd>Page Down</kbd> -> Next slide
