### PR TITLE
Add support for better highlighting. Addressing issue #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ you will notice that this README.mb is a valid tslide markdown presentation.
 
 ---
 
-## crude js syntax highlighting
+## Advanced syntax highlighting
 
 ```md
 # tslide
@@ -38,6 +38,15 @@ function fibonacci (n) {
 ‘‘‘
 
 ```
+
+## JavaScript Example
+
+```js
+function fibonacci (n) {
+  return n < 2 ? n : fibonacci(n - 1) + fibonacci(n - 2)
+}
+```
+
 ---
 
 ![Demo Code](demo-code.png)

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "ansi-escapes": "^1.3.0",
+    "chalk": "^1.1.3",
     "charm": "~0.1.0",
     "color": "~0.4.1",
     "colors": "~0.6.0-1",
@@ -15,6 +16,8 @@
     "insert-queue": "0.0.4",
     "keypress": "~0.1.0",
     "markdown-sections": "~1.0.1",
+    "marked": "^0.3.6",
+    "marked-terminal": "^1.6.2",
     "node-emoji": "^1.3.1",
     "optimist": "~0.3.4"
   },


### PR DESCRIPTION
I didn't update the screenshots. I suggest you to clone my fork to actually test it out. Feedback is more than welcome 🙂 

You can switch back to the previous style of highlighting by running `tslide README.md --legacy`. 
