### PR TITLE
Fix markdown headers from showing escape characters inside code sections

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ function indent(slide, indent) {
   var code = false
   var inlineBold = /\*\*(.*)\*\*/g
   return slide.split('\n').map(function (l) {
-    if(/^#/.test(l))
+    if(/^#/.test(l) && !code)
       l = l.bold
     if(/^```/.test(l))
       code = !code


### PR DESCRIPTION
This is a bandaid, which fixes #19. It makes sure our current (soon legacy?) renderer works correctly for our main example: our `README.md`.

If you were to dive deeper into this issue (dominictarr is probably aware already), then we'd see that there isn't graceful support for nested code ``` sections, as well as non-javascript hightlighted coded sections. To do this, we'd need a bunch of code or a Lexer(?). It isn't worth the effort since #17 will fix this for new users, once merged.
