### PR TITLE
Add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# tslide is an [OPEN Open Source Project][openopensource]
+
+-----------------------------------------
+
+## What?
+
+Individuals making significant and valuable contributions are given commit-access to the project to contribute as they see fit.
+
+## Rules
+
+There are a few basic ground-rules for contributors:
+
+1. **No `--force` pushes** or modifying the Git history in any way.
+1. **Non-master branches** ought to be used for ongoing work.
+1. **External API changes and significant modifications** ought to be subject to an **internal pull-request** to solicit feedback from other contributors.
+1. Internal pull-requests to solicit feedback are *encouraged* for any other non-trivial contribution but left to the discretion of the contributor.
+1. Contributors should attempt to adhere to the prevailing code-style.
+
+## Releases
+
+Declaring formal releases remains the prerogative of the project maintainer.
+
+## Changes to this arrangement
+
+This document may also be subject to updates from the [original manifesto][manifesto], seperate pull-requests or changes by contributors where they believe they have something valuable to add or change.
+
+[openopensource]: http://openopensource.org/
+[manifesto]: https://raw.githubusercontent.com/openopensource/openopensource.github.io/master/Readme.md


### PR DESCRIPTION
This guide was sourced from [OPEN Open Source Project](http://openopensource.org/). It is a Liberal Contribution Model and as far as I can tell suits this project, project leader, and contributors. 👍 

I'm adding it because a couple days ago I thought of fixing something in this project, but couldn't remember off of the top of my head the contribution model we use haha.

I've modified the source manifesto in places to read correctly in this project's context.
